### PR TITLE
Memoria como elemento  independiente

### DIFF
--- a/Latex/memoria.tex
+++ b/Latex/memoria.tex
@@ -475,8 +475,9 @@ keywords separated by commas.
 
 \mainmatter
 
-\addcontentsline{toc}{part}{Memoria}
 \part*{Memoria}
+\addcontentsline{toc}{part}{Memoria}
+
 
 \include{./tex/1_Introduccion}
 \include{./tex/2_Objetivos_del_proyecto}


### PR DESCRIPTION
He movido la posición de \part*{Memoria} para que el apartado Memoria aparezca como un elemento independiente en el índice y no como parte de \listoftables.
![despues](https://user-images.githubusercontent.com/48088497/176167820-76991a07-bccc-48f3-8729-a88b78f45705.PNG)
![antes](https://user-images.githubusercontent.com/48088497/176167821-d40b7e70-edf8-41f9-9873-e0f151d27bb3.PNG)

